### PR TITLE
Поддержка welcome.wi-fi.ru (MosMetroV3)

### DIFF
--- a/app/src/androidTest/java/pw/thedrhax/mosmetro/httpclient/ClientTest.java
+++ b/app/src/androidTest/java/pw/thedrhax/mosmetro/httpclient/ClientTest.java
@@ -1,0 +1,26 @@
+package pw.thedrhax.mosmetro.httpclient;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * A collection of the Client class tests
+ * @author Dmitry Karikh <the.dr.hax@gmail.com>
+ * @see pw.thedrhax.mosmetro.httpclient.Client
+ */
+public class ClientTest {
+    @Test
+    public void requestToString() throws Exception {
+        Map<String,String> params = new HashMap<>();
+
+        params.put("test", "123");
+        assertEquals("?test=123", Client.requestToString(params));
+
+        params.put("foo", "bar");
+        assertEquals("?test=123&foo=bar", Client.requestToString(params));
+    }
+}

--- a/app/src/androidTest/java/pw/thedrhax/mosmetro/httpclient/ParsedResponseTest.java
+++ b/app/src/androidTest/java/pw/thedrhax/mosmetro/httpclient/ParsedResponseTest.java
@@ -26,9 +26,9 @@ import junit.framework.TestCase;
 import pw.thedrhax.mosmetro.httpclient.clients.OkHttp;
 
 /**
- * A collection of the Client class tests
+ * A collection of the ParsedResponse class tests
  * @author Dmitry Karikh <the.dr.hax@gmail.com>
- * @see pw.thedrhax.mosmetro.httpclient.Client
+ * @see pw.thedrhax.mosmetro.httpclient.ParsedResponse
  */
 public class ParsedResponseTest extends TestCase {
     private Context context = InstrumentationRegistry.getContext();

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
@@ -94,7 +94,7 @@ public abstract class Provider extends LinkedList<Task> {
      *
      * @see Client
      */
-    @NonNull static Provider find(Context context, ParsedResponse response) {
+    @NonNull public static Provider find(Context context, ParsedResponse response) {
         if (MosMetroV3.match(response)) return new MosMetroV3(context);
         else if (MosMetroV2.match(response)) return new MosMetroV2(context);
         else if (MosMetroV1.match(response)) return new MosMetroV1(context);
@@ -247,6 +247,13 @@ public abstract class Provider extends LinkedList<Task> {
      */
     public Provider setRunningListener(Listener<Boolean> master) {
         running.subscribe(master); return this;
+    }
+
+    /**
+     * Replace default Client
+     */
+    public Provider setClient(Client client) {
+        this.client = client; return this;
     }
 
     /**

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
@@ -31,6 +31,7 @@ import pw.thedrhax.mosmetro.R;
 import pw.thedrhax.mosmetro.authenticator.providers.Enforta;
 import pw.thedrhax.mosmetro.authenticator.providers.MosMetroV1;
 import pw.thedrhax.mosmetro.authenticator.providers.MosMetroV2;
+import pw.thedrhax.mosmetro.authenticator.providers.MosMetroV3;
 import pw.thedrhax.mosmetro.authenticator.providers.Unknown;
 import pw.thedrhax.mosmetro.httpclient.Client;
 import pw.thedrhax.mosmetro.httpclient.ParsedResponse;
@@ -94,7 +95,8 @@ public abstract class Provider extends LinkedList<Task> {
      * @see Client
      */
     @NonNull static Provider find(Context context, ParsedResponse response) {
-        if (MosMetroV2.match(response)) return new MosMetroV2(context);
+        if (MosMetroV3.match(response)) return new MosMetroV3(context);
+        else if (MosMetroV2.match(response)) return new MosMetroV2(context);
         else if (MosMetroV1.match(response)) return new MosMetroV1(context);
         else if (Enforta.match(response)) return new Enforta(context);
         else return new Unknown(context, response);

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV2.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV2.java
@@ -42,9 +42,10 @@ import pw.thedrhax.util.Logger;
 import pw.thedrhax.util.Randomizer;
 
 /**
- * The MosMetroV2 class supports the actual version of the MosMetro algorithm.
+ * The MosMetroV2 class implements support for auth.wi-fi.ru algorithm.
  *
- * Detection: Meta-redirect contains ".wi-fi.ru" with any 3rd level domain (except "login").
+ * Detection: Meta-redirect contains ".wi-fi.ru" with any 3rd level domain
+ * (except "login" or "welcome").
  *
  * @author Dmitry Karikh <the.dr.hax@gmail.com>
  * @see Provider
@@ -58,7 +59,7 @@ public class MosMetroV2 extends Provider {
 
         /**
          * Checking Internet connection for a first time
-         * ⇒ GET http://wi-fi.ru
+         * ⇒ GET generate_204
          * ⇐ Meta-redirect: http://auth.wi-fi.ru/?segment=... > redirect, segment
          */
         add(new NamedTask(context.getString(R.string.auth_checking_connection)) {
@@ -92,31 +93,6 @@ public class MosMetroV2 extends Provider {
                     ));
                     vars.put("result", RESULT.NOT_REGISTERED);
                     return false;
-                }
-                return true;
-            }
-        });
-
-        /**
-         * Checking for bad redirect
-         * redirect ~= welcome.wi-fi.ru
-         */
-        add(new Task() {
-            @Override
-            public boolean run(HashMap<String, Object> vars) {
-                if (redirect.contains("welcome.wi-fi.ru")) {
-                    Logger.log(Logger.LEVEL.DEBUG, "Found redirect to welcome.wi-fi.ru!");
-                    try {
-                        client.get(redirect, null, pref_retry_count);
-                        Logger.log(Logger.LEVEL.DEBUG, client.response().getPage());
-                    } catch (IOException ex) {
-                        Logger.log(Logger.LEVEL.DEBUG, ex);
-                    }
-
-                    redirect = Uri.parse(redirect).buildUpon()
-                            .authority("auth.wi-fi.ru")
-                            .build().toString();
-                    Logger.log(Logger.LEVEL.DEBUG, redirect);
                 }
                 return true;
             }
@@ -382,6 +358,8 @@ public class MosMetroV2 extends Provider {
             }
         }
 
-        return redirect.contains(".wi-fi.ru") && !redirect.contains("login.wi-fi.ru");
+        return redirect.contains(".wi-fi.ru")
+                && !redirect.contains("login.wi-fi.ru")
+                && !redirect.contains("welcome.wi-fi.ru");
     }
 }

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
@@ -1,0 +1,290 @@
+package pw.thedrhax.mosmetro.authenticator.providers;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.net.Uri;
+
+import org.json.simple.JSONObject;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+
+import pw.thedrhax.mosmetro.R;
+import pw.thedrhax.mosmetro.authenticator.NamedTask;
+import pw.thedrhax.mosmetro.authenticator.Provider;
+import pw.thedrhax.mosmetro.httpclient.Client;
+import pw.thedrhax.mosmetro.httpclient.ParsedResponse;
+import pw.thedrhax.mosmetro.httpclient.clients.OkHttp;
+import pw.thedrhax.util.Logger;
+
+/**
+ * The MosMetroV3 class implements support for welcome.wi-fi.ru algorithm.
+ *
+ * Detection: Meta or Location redirect contains "welcome.wi-fi.ru".
+ *
+ * @author Dmitry Karikh <the.dr.hax@gmail.com>
+ * @see Provider
+ */
+
+public class MosMetroV3 extends Provider {
+    private String redirect = "http://welcome.wi-fi.ru/?client_mac=00-00-00-00-00-00";
+
+    public MosMetroV3(final Context context) {
+        super(context);
+
+        /**
+         * Checking Internet connection for a first time
+         * ⇒ GET generate_204
+         * ⇐ Meta + Location redirect: http://welcome.wi-fi.ru/?client_mac=... > redirect, mac
+         */
+        add(new NamedTask(context.getString(R.string.auth_checking_connection)) {
+            @Override
+            public boolean run(HashMap<String, Object> vars) {
+                if (isConnected()) {
+                    Logger.log(context.getString(R.string.auth_already_connected));
+                    vars.put("result", RESULT.ALREADY_CONNECTED);
+                    return false;
+                } else {
+                    if (redirect.contains("client_mac")) {
+                        vars.put("mac", Uri.parse(redirect).getQueryParameter("client_mac"));
+                    } else {
+                        vars.put("mac", "00-00-00-00-00-00");
+                    }
+                    redirect = ParsedResponse.removePathFromUrl(redirect);
+                    return true;
+                }
+            }
+        });
+
+        /**
+         * Getting auth page
+         * ⇒ GET redirect + /?client_mac=mac < redirect, mac
+         * ⇐ 200 OK
+         * ⇐ Meta csrf-token > token
+         */
+        add(new NamedTask(context.getString(R.string.auth_auth_page)) {
+            @Override
+            public boolean run(HashMap<String, Object> vars) {
+                try {
+                    Map<String,String> params = new HashMap<>();
+                    params.put("client_mac", (String)vars.get("mac"));
+
+                    client.get(redirect, params, pref_retry_count);
+                    Logger.log(Logger.LEVEL.DEBUG, client.response().getPageContent().outerHtml());
+                } catch (IOException ex) {
+                    Logger.log(Logger.LEVEL.DEBUG, ex);
+                    Logger.log(context.getString(R.string.error,
+                            context.getString(R.string.auth_error_auth_page)
+                    ));
+                    return false;
+                }
+
+                try {
+                    String token = client.response().parseMetaContent("csrf-token");
+                    Logger.log(Logger.LEVEL.DEBUG, "CSRF token parsed: " + token);
+                    vars.put("token", token);
+                } catch (ParseException ex) {
+                    Logger.log(Logger.LEVEL.DEBUG, ex);
+                    Logger.log(context.getString(R.string.error,
+                            "CSRF token not found"
+                    ));
+                    return false;
+                }
+
+                return true;
+            }
+        });
+
+        /**
+         * Initializing auth procedure
+         * ⇒ POST redirect + /auth/init < redirect
+         * ⇒ JSON: { "authenticity_token": token, "client_mac": mac, "client_ip": "" } < token, mac
+         * ⇐ JSON: { "result": true, "user_mac": ..., "auth_status": "initial" }
+         */
+        add(new NamedTask("Initializing auth procedure") {
+            @Override @SuppressLint("HardwareIds")
+            public boolean run(HashMap<String, Object> vars) {
+                try {
+                    JSONObject body = new JSONObject();
+                    body.put("authenticity_token", vars.get("token"));
+                    body.put("user_mac", vars.get("mac"));
+                    body.put("client_ip", "");
+
+                    client.post(
+                            redirect + "/auth/init",
+                            "application/json; charset=UTF-8",
+                            body.toString(),
+                            pref_retry_count
+                    );
+                    Logger.log(Logger.LEVEL.DEBUG, client.response().getPage());
+                } catch (IOException ex) {
+                    Logger.log(Logger.LEVEL.DEBUG, ex);
+                    Logger.log(context.getString(R.string.error,
+                            context.getString(R.string.auth_error_server)
+                    ));
+                    return false;
+                }
+
+                try {
+                    JSONObject answer = client.response().json();
+                    boolean result = answer.containsKey("result") && answer.get("result").equals(true);
+
+                    if (!result) {
+                        Logger.log(context.getString(R.string.error,
+                                "Unexpected answer: false"
+                        ));
+                        return false;
+                    }
+                } catch (org.json.simple.parser.ParseException ex) {
+                    Logger.log(Logger.LEVEL.DEBUG, ex);
+                    Logger.log(context.getString(R.string.error,
+                            context.getString(R.string.auth_error_server)
+                    ));
+                    return false;
+                }
+
+                return true;
+            }
+        });
+
+        /**
+         * Checking auth status
+         * ⇒ GET redirect + /auth/check?client_mac=mac&client_ip= < redirect, mac
+         * ⇐ TODO: 304 Not Modified?
+         */
+        add(new NamedTask("Checking auth status") {
+            @Override
+            public boolean run(HashMap<String, Object> vars) {
+                try {
+                    Map<String,String> params = new HashMap<>();
+                    params.put("client_mac", (String)vars.get("mac"));
+                    params.put("client_ip", "");
+
+                    client.get(redirect + "/auth/check", params, pref_retry_count);
+                    Logger.log(Logger.LEVEL.DEBUG, client.response().getPage());
+                } catch (IOException ex) {
+                    Logger.log(Logger.LEVEL.DEBUG, ex);
+                }
+                return true;
+            }
+        });
+
+        /**
+         * Finishing auth procedure
+         * ⇒ GET redirect + /success?client_mac=mac < redirect, mac
+         * ⇐ Location: http://gowifi.ru
+         */
+        add(new NamedTask("Finishing auth procedure") {
+            @Override
+            public boolean run(HashMap<String, Object> vars) {
+                try {
+                    Map<String,String> params = new HashMap<>();
+                    params.put("client_mac", (String)vars.get("mac"));
+
+                    client.get(redirect + "/success", params, pref_retry_count);
+                    Logger.log(Logger.LEVEL.DEBUG, client.response().getPage());
+
+                    redirect = client.response().get300Redirect();
+                    Logger.log(Logger.LEVEL.DEBUG, redirect);
+                } catch (IOException ex) {
+                    Logger.log(Logger.LEVEL.DEBUG, ex);
+                    Logger.log(context.getString(R.string.error,
+                            context.getString(R.string.auth_error_server)
+                    ));
+                    return false;
+                } catch (ParseException ex) {
+                    Logger.log(Logger.LEVEL.DEBUG, ex);
+                    Logger.log(context.getString(R.string.error,
+                            context.getString(R.string.auth_error_redirect)
+                    ));
+                    return false;
+                }
+                return true;
+            }
+        });
+
+        /**
+         * Following the last redirect
+         * ⇒ GET redirect
+         * ⇐ Location: http://wi-fi.ru
+         */
+        add(new NamedTask("Following the last redirect") {
+            @Override
+            public boolean run(HashMap<String, Object> vars) {
+                try {
+                    client.get(redirect, null, pref_retry_count);
+                    Logger.log(Logger.LEVEL.DEBUG, redirect);
+                } catch (IOException ex) {
+                    Logger.log(Logger.LEVEL.DEBUG, ex);
+                }
+                return true;
+            }
+        });
+
+        /**
+         * Checking Internet connection
+         * ⇒ GET generate_204
+         * ⇐ GOOD: 204 No Content
+         * ⇐ BAD: Meta + Location redirect: http://welcome.wi-fi.ru/?client_mac=... > redirect, mac
+         * ⇐ OKAY: Meta + Location redirect: http://auth.wi-fi.ru/?segment=... > redirect
+         */
+        add(new NamedTask(context.getString(R.string.auth_checking_connection)) {
+            @Override
+            public boolean run(HashMap<String, Object> vars) {
+                Provider provider = Provider.find(context, running).setCallback(callback);
+
+                if (provider instanceof Unknown && isConnected()) {
+                    Logger.log(context.getString(R.string.auth_connected));
+                    vars.put("result", RESULT.CONNECTED);
+                } else if (provider instanceof MosMetroV3) {
+                    Logger.log(context.getString(R.string.error,
+                            "Infinite loop!"
+                    ));
+                } else {
+                    Logger.log("Switching to another algorithm: " + provider.getName());
+                    RESULT result = provider.start();
+                    vars.put("result", result);
+                }
+
+                return false;
+            }
+        });
+    }
+
+    @Override
+    public boolean isConnected() {
+        Client client = new OkHttp(context).followRedirects(false);
+        try {
+            client.get("http://" + random.choose(GENERATE_204), null, pref_retry_count);
+        } catch (IOException ex) {
+            Logger.log(Logger.LEVEL.DEBUG, ex);
+            return false;
+        }
+
+        try {
+            redirect = client.response().parseMetaRedirect();
+            Logger.log(Logger.LEVEL.DEBUG, redirect);
+        } catch (ParseException ex) {
+            // Redirect not found => connected
+            return super.isConnected();
+        }
+
+        // Redirect found => not connected
+        return false;
+    }
+
+    /**
+     * Checks if current network is supported by this Provider implementation.
+     * @param response  Instance of ParsedResponse.
+     * @return          True if response matches this Provider implementation.
+     */
+    public static boolean match(ParsedResponse response) {
+        try {
+            return response.parseMetaRedirect().contains("welcome.wi-fi.ru");
+        } catch (ParseException ex) {
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
@@ -107,7 +107,7 @@ public class MosMetroV3 extends Provider {
                 try {
                     JSONObject body = new JSONObject();
                     body.put("authenticity_token", vars.get("token"));
-                    body.put("user_mac", vars.get("mac"));
+                    body.put("client_mac", vars.get("mac"));
                     body.put("client_ip", "");
 
                     Logger.log(Logger.LEVEL.DEBUG, "POST /auth/init");

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
@@ -110,8 +110,6 @@ public class MosMetroV3 extends Provider {
                     body.put("client_mac", vars.get("mac"));
                     body.put("client_ip", "");
 
-                    Logger.log(Logger.LEVEL.DEBUG, "POST /auth/init");
-                    Logger.log(Logger.LEVEL.DEBUG, "Body: " + body.toJSONString());
                     client.post(
                             redirect + "/auth/init",
                             "application/json; charset=UTF-8",

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
@@ -101,7 +101,7 @@ public class MosMetroV3 extends Provider {
          * ⇒ JSON: { "authenticity_token": token, "client_mac": mac, "client_ip": "" } < token, mac
          * ⇐ JSON: { "result": true, "user_mac": ..., "auth_status": "initial" }
          */
-        add(new NamedTask("Initializing auth procedure") {
+        add(new NamedTask(context.getString(R.string.auth_init)) {
             @Override @SuppressLint("HardwareIds")
             public boolean run(HashMap<String, Object> vars) {
                 try {
@@ -128,14 +128,10 @@ public class MosMetroV3 extends Provider {
                 try {
                     JSONObject answer = client.response().json();
                     boolean result = answer.containsKey("result") && answer.get("result").equals(true);
-
                     if (!result) {
-                        Logger.log(context.getString(R.string.error,
-                                "Unexpected answer: false"
-                        ));
-                        return false;
+                        throw new Exception("Unexpected answer: false");
                     }
-                } catch (org.json.simple.parser.ParseException ex) {
+                } catch (Exception ex) {
                     Logger.log(Logger.LEVEL.DEBUG, ex);
                     Logger.log(context.getString(R.string.error,
                             context.getString(R.string.auth_error_server)
@@ -152,7 +148,7 @@ public class MosMetroV3 extends Provider {
          * ⇒ GET redirect + /auth/check?client_mac=mac&client_ip= < redirect, mac
          * ⇐ TODO: 304 Not Modified?
          */
-        add(new NamedTask("Checking auth status") {
+        add(new NamedTask(context.getString(R.string.auth_check)) {
             @Override
             public boolean run(HashMap<String, Object> vars) {
                 try {
@@ -174,7 +170,7 @@ public class MosMetroV3 extends Provider {
          * ⇒ GET redirect + /success?client_mac=mac < redirect, mac
          * ⇐ Location redirect > client.response()
          */
-        add(new NamedTask("Finishing auth procedure") {
+        add(new NamedTask(context.getString(R.string.auth_finish)) {
             @Override
             public boolean run(HashMap<String, Object> vars) {
                 try {
@@ -216,7 +212,9 @@ public class MosMetroV3 extends Provider {
                             "Infinite loop!"
                     ));
                 } else {
-                    Logger.log("Switching to another algorithm: " + provider.getName());
+                    Logger.log(context.getString(R.string.auth_algorithm_switch,
+                            provider.getName()
+                    ));
                     RESULT result = provider.start();
                     vars.put("result", result);
                 }

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
@@ -82,9 +82,7 @@ public class MosMetroV3 extends Provider {
                 }
 
                 try {
-                    String token = client.response().parseMetaContent("csrf-token");
-                    Logger.log(Logger.LEVEL.DEBUG, "CSRF token parsed: " + token);
-                    vars.put("token", token);
+                    vars.put("token", client.response().parseMetaContent("csrf-token"));
                 } catch (ParseException ex) {
                     Logger.log(Logger.LEVEL.DEBUG, ex);
                     Logger.log(context.getString(R.string.error,
@@ -112,10 +110,12 @@ public class MosMetroV3 extends Provider {
                     body.put("user_mac", vars.get("mac"));
                     body.put("client_ip", "");
 
+                    Logger.log(Logger.LEVEL.DEBUG, "POST /auth/init");
+                    Logger.log(Logger.LEVEL.DEBUG, "Body: " + body.toJSONString());
                     client.post(
                             redirect + "/auth/init",
                             "application/json; charset=UTF-8",
-                            body.toString(),
+                            body.toJSONString(),
                             pref_retry_count
                     );
                     Logger.log(Logger.LEVEL.DEBUG, client.response().getPage());

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV3.java
@@ -208,13 +208,15 @@ public class MosMetroV3 extends Provider {
                     Logger.log(context.getString(R.string.auth_connected));
                     vars.put("result", RESULT.CONNECTED);
                 } else if (provider instanceof MosMetroV3) {
-                    Logger.log(context.getString(R.string.error,
-                            "Infinite loop!"
-                    ));
+                    Logger.log(context.getString(R.string.error, "Infinite loop!"));
                 } else {
-                    Logger.log(context.getString(R.string.auth_algorithm_switch,
-                            provider.getName()
-                    ));
+                    if (provider instanceof Unknown) {
+                        Logger.log(context.getString(R.string.auth_unknown_redirect));
+                        provider = Provider.find(context, running)
+                                .setClient(client).setCallback(callback);
+                    }
+
+                    Logger.log(context.getString(R.string.auth_algorithm_switch, provider.getName()));
                     RESULT result = provider.start();
                     vars.put("result", result);
                 }

--- a/app/src/main/java/pw/thedrhax/mosmetro/httpclient/Client.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/httpclient/Client.java
@@ -111,6 +111,7 @@ public abstract class Client {
     // IO methods
     public abstract ParsedResponse get(String link, Map<String,String> params) throws IOException;
     public abstract ParsedResponse post(String link, Map<String,String> params) throws IOException;
+    public abstract ParsedResponse post(String link, String type, String body) throws IOException;
     public abstract InputStream getInputStream(String link) throws IOException;
 
     private ParsedResponse saveResponse(ParsedResponse response) {
@@ -152,6 +153,18 @@ public abstract class Client {
                     random.delay(running);
                 }
                 return saveResponse(post(link, params));
+            }
+        }.run(retries);
+    }
+    public ParsedResponse post(final String link, final String type, final String body,
+                               int retries) throws IOException {
+        return new RetryOnException<ParsedResponse>() {
+            @Override
+            public ParsedResponse body() throws IOException {
+                if (random_delays) {
+                    random.delay(running);
+                }
+                return saveResponse(post(link, type, body));
             }
         }.run(retries);
     }

--- a/app/src/main/java/pw/thedrhax/mosmetro/httpclient/ParsedResponse.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/httpclient/ParsedResponse.java
@@ -218,9 +218,7 @@ public class ParsedResponse {
                 String url = absolutePathToUrl(document.location(), link);
                 if (!result.contains(url))
                     result.add(url);
-            } catch (ParseException ex) {
-                Logger.log(Logger.LEVEL.DEBUG, ex);
-            }
+            } catch (ParseException ignored) {}
         }
 
         return result;

--- a/app/src/main/java/pw/thedrhax/mosmetro/httpclient/clients/OkHttp.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/httpclient/clients/OkHttp.java
@@ -45,8 +45,10 @@ import okhttp3.Cookie;
 import okhttp3.CookieJar;
 import okhttp3.FormBody;
 import okhttp3.HttpUrl;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import pw.thedrhax.mosmetro.httpclient.Client;
@@ -150,7 +152,7 @@ public class OkHttp extends Client {
         return this;
     }
 
-    private Response call(String url, FormBody data) throws IOException {
+    private Response call(String url, RequestBody data) throws IOException {
         Request.Builder builder = new Request.Builder().url(url);
 
         // Choose appropriate request method
@@ -201,6 +203,11 @@ public class OkHttp extends Client {
         }
 
         return parse(call(link, body.build()));
+    }
+
+    @Override
+    public ParsedResponse post(String link, String type, String body) throws IOException {
+        return parse(call(link, RequestBody.create(MediaType.parse(type), body)));
     }
 
     @Override

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -102,6 +102,10 @@
     <string name="auth_waiting">Ожидание…</string>
     <string name="auth_checking_connection">Проверка доступа в интернет</string>
     <string name="auth_already_connected">Уже подключено</string>
+    <string name="auth_init">Инициализация процесса авторизации</string>
+    <string name="auth_check">Проверка состояния авторизации</string>
+    <string name="auth_finish">Завершение процесса авторизации</string>
+    <string name="auth_algorithm_switch">Переключаюсь на другой алгоритм: %s</string>
     <string name="auth_redirect">Получение перенаправления</string>
     <string name="auth_auth_page">Получение страницы авторизации</string>
     <string name="auth_auth_form">Отправка формы авторизации</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -105,6 +105,7 @@
     <string name="auth_init">Инициализация процесса авторизации</string>
     <string name="auth_check">Проверка состояния авторизации</string>
     <string name="auth_finish">Завершение процесса авторизации</string>
+    <string name="auth_unknown_redirect">Получено неизвестное перенаправление. Пытаюсь определить алгоритм…</string>
     <string name="auth_algorithm_switch">Переключаюсь на другой алгоритм: %s</string>
     <string name="auth_redirect">Получение перенаправления</string>
     <string name="auth_auth_page">Получение страницы авторизации</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="auth_init">Initializing auth procedure</string>
     <string name="auth_check">Checking auth status</string>
     <string name="auth_finish">Finishing auth procedure</string>
+    <string name="auth_unknown_redirect">Unknown redirect. Trying to detect algorithm…</string>
     <string name="auth_algorithm_switch">Switching to another algorithm: %s</string>
     <string name="auth_redirect">Getting redirection</string>
     <string name="auth_auth_page">Getting login page</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,10 @@
     <string name="auth_waiting">Waiting…</string>
     <string name="auth_checking_connection">Checking Internet connection</string>
     <string name="auth_already_connected">Already connected</string>
+    <string name="auth_init">Initializing auth procedure</string>
+    <string name="auth_check">Checking auth status</string>
+    <string name="auth_finish">Finishing auth procedure</string>
+    <string name="auth_algorithm_switch">Switching to another algorithm: %s</string>
     <string name="auth_redirect">Getting redirection</string>
     <string name="auth_auth_page">Getting login page</string>
     <string name="auth_auth_form">Sending login form</string>


### PR DESCRIPTION
Довольно давно в сети метро, а затем и в других, появился домен welcome.wi-fi.ru, на который иногда выдаётся перенаправление. До этого момента приложение игнорировало такие случаи и пыталось подключиться напрямую через auth.wi-fi.ru. Однако в последнее время всё чаще возникают проблемы в Санкт-Петербурге, причиной чего может быть именно "welcome".

* [x] Создать класс MosMetroV3
* [x] Определить критерии выбора этого алгоритма: **Meta перенаправление на welcome.wi-fi.ru**
* Реализовать последовательность запросов
  * [x] GET welcome.wi-fi.ru/?client_mac=...
  * [x] POST welcome.wi-fi.ru/auth/init
  * [x] GET welcome.wi-fi.ru/auth/check?client_mac=...&client_ip=
  * [x] GET welcome.wi-fi.ru/success?client_mac=...
  * [x] Переход к другому алгоритму в случае необходимости
  * [x] Финальный тест (сборка №4)
* Другое:
  * [x] Экспортировать сообщения в strings.xml и перевести их на русский
  * [ ] Определение необходимости регистрации устройства