### PR TITLE
Восстановление работы автоподключения на Android Pie

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
-
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <application
         android:name=".MosMetroApp"
         android:allowBackup="true"

--- a/app/src/main/java/pw/thedrhax/mosmetro/activities/SettingsActivity.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/activities/SettingsActivity.java
@@ -381,7 +381,7 @@ public class SettingsActivity extends Activity {
                 dialog.show();
     }
 
-    @RequiresApi(27)
+    @RequiresApi(28)
     private void location_permission_setup() {
         Context context = this;
         boolean location_denied = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
@@ -554,7 +554,7 @@ public class SettingsActivity extends Activity {
         update_checker_setup();
         if (Build.VERSION.SDK_INT >= 23)
             energy_saving_setup();
-        if (Build.VERSION.SDK_INT >= 27)
+        if (Build.VERSION.SDK_INT >= 28)
             location_permission_setup();
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -211,4 +211,6 @@
     <string name="pref_debug_last_log">Хранить последний лог</string>
     <string name="pref_debug_last_log_summary">Лог будет записываться во внутреннее хранилище приложения и отправляться вместе с отчетами ACRA в случае сбоя.</string>
     <string name="auth_algorithm_failure">не удалось инициализировать алгоритм</string>
+    <string name="location_permission_saving">Определение местоположения</string>
+    <string name="location_permission_saving_summary">Начиная с Android 9.0 для работы автоматического подключения требуется предоставление права на использование местоположения. В противном случае будет работать только ручное подключение</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,4 +233,6 @@
     <string name="pref_debug_last_log">Store the last log</string>
     <string name="pref_debug_last_log_summary">Log will be written into internal storage of the application. It will be sent along with ACRA reports in case of crash.</string>
     <string name="auth_algorithm_failure">algorithm initialization failed</string>
+    <string name="location_permission_saving">Location permission</string>
+    <string name="location_permission_saving_summary">Starting with Android 9.0, you need grant location permission to this application, so that it can automatically connect to network. Otherwise, only manual connection will be available</string>
 </resources>


### PR DESCRIPTION
Для исправления в манифест добавлено новое разрешение (COARSE_LOCATION). Также добавлено окно с просьбой дать права на использование разрешения с предупреждением, что будет, если не дать.

Вариант решения без использования нового разрешения, описанный по ссылке на Stack Overflow в https://github.com/mosmetro-android/mosmetro-android/pull/197 не работает на Pie (как минимум на моем устройстве).