### PR TITLE
Проверка сети по DNS при неизвестном SSID

### DIFF
--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
@@ -25,8 +25,11 @@ import androidx.annotation.NonNull;
 
 import org.acra.ACRA;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 
 import pw.thedrhax.mosmetro.R;
 import pw.thedrhax.mosmetro.authenticator.providers.MAInet;
@@ -37,6 +40,7 @@ import pw.thedrhax.mosmetro.authenticator.providers.MosMetroV2WV;
 import pw.thedrhax.mosmetro.authenticator.providers.MosMetroV3;
 import pw.thedrhax.mosmetro.authenticator.providers.Unknown;
 import pw.thedrhax.mosmetro.httpclient.Client;
+import pw.thedrhax.mosmetro.httpclient.DnsClient;
 import pw.thedrhax.mosmetro.httpclient.HttpResponse;
 import pw.thedrhax.mosmetro.httpclient.clients.OkHttp;
 import pw.thedrhax.util.Listener;
@@ -68,6 +72,13 @@ public abstract class Provider extends LinkedList<Task> implements Task {
             "bmstu_lb"
     };
 
+    /**
+     * List of domains for DNS probing
+     */
+    protected static final String[] DOMAINS = {
+            "auth.wi-fi.ru"
+    };
+
     protected Context context;
     protected SharedPreferences settings;
     protected Randomizer random;
@@ -78,6 +89,38 @@ public abstract class Provider extends LinkedList<Task> implements Task {
      * Default Client used for all network operations
      */
     protected Client client;
+
+    /**
+     * Check if current network is supported by sending simple DNS requests.
+     * @return True if any of responses contains a site-local IP.
+     */
+    public static boolean dnsCheck(Context context) {
+        Logger.log(Logger.LEVEL.DEBUG, "Performing DNS check...");
+
+        DnsClient dns = new DnsClient(context);
+
+        for (String domain : DOMAINS) {
+            List<InetAddress> res;
+
+            try {
+                res = dns.lookup(domain);
+            } catch (UnknownHostException ex) {
+                Logger.log(dns, "Unable to resolve " + domain);
+                continue;
+            }
+
+            for (InetAddress addr : res) {
+                Logger.log(dns, addr.toString());
+
+                if (addr.isSiteLocalAddress()) {
+                    Logger.log(Logger.LEVEL.DEBUG, "Found site-local address " + addr);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Find Provider using already received response from server.

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
@@ -97,7 +97,7 @@ public abstract class Provider extends LinkedList<Task> implements Task {
     public static boolean dnsCheck(Context context) {
         Logger.log(Logger.LEVEL.DEBUG, "Performing DNS check...");
 
-        DnsClient dns = new DnsClient(context).useCustomClient(true);
+        DnsClient dns = new DnsClient(context).useCustomClient(true).useGlobalCache(false);
 
         for (String domain : DOMAINS) {
             List<InetAddress> res;

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
@@ -72,13 +72,6 @@ public abstract class Provider extends LinkedList<Task> implements Task {
             "bmstu_lb"
     };
 
-    /**
-     * List of domains for DNS probing
-     */
-    protected static final String[] DOMAINS = {
-            "auth.wi-fi.ru"
-    };
-
     protected Context context;
     protected SharedPreferences settings;
     protected Randomizer random;
@@ -90,6 +83,23 @@ public abstract class Provider extends LinkedList<Task> implements Task {
      */
     protected Client client;
 
+    protected static List<String> getDnsCheckDomains(Context context) {
+        LinkedList<String> result = new LinkedList<>();
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
+
+        result.add("auth.wi-fi.ru");
+
+        if (!settings.getString("pref_bmstu_credentials_login", "").isEmpty()) {
+            result.add("lbpfs.bmstu.ru");
+        }
+
+        if (!settings.getString("pref_mainet_credentials_login", "").isEmpty()) {
+            result.add("wifi.mai.ru");
+        }
+
+        return result;
+    }
+
     /**
      * Check if current network is supported by sending simple DNS requests.
      * @return True if any of responses contains a site-local IP.
@@ -99,7 +109,7 @@ public abstract class Provider extends LinkedList<Task> implements Task {
 
         DnsClient dns = new DnsClient(context).useCustomClient(true).useGlobalCache(false);
 
-        for (String domain : DOMAINS) {
+        for (String domain : getDnsCheckDomains(context)) {
             List<InetAddress> res;
 
             try {

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
@@ -97,7 +97,7 @@ public abstract class Provider extends LinkedList<Task> implements Task {
     public static boolean dnsCheck(Context context) {
         Logger.log(Logger.LEVEL.DEBUG, "Performing DNS check...");
 
-        DnsClient dns = new DnsClient(context);
+        DnsClient dns = new DnsClient(context).useCustomClient(true);
 
         for (String domain : DOMAINS) {
             List<InetAddress> res;

--- a/app/src/main/java/pw/thedrhax/mosmetro/httpclient/DnsClient.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/httpclient/DnsClient.java
@@ -19,6 +19,7 @@
 package pw.thedrhax.mosmetro.httpclient;
 
 import org.xbill.DNS.ARecord;
+import org.xbill.DNS.Cache;
 import org.xbill.DNS.Lookup;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.ResolverConfig;
@@ -45,6 +46,7 @@ public class DnsClient implements Dns {
     private final WifiUtils wifi;
     private ExtendedResolver dns;
     private boolean pref_dnsjava;
+    private boolean global_cache = true;
 
     private String[] getServers() {
         Set<String> servers = new HashSet<String>();
@@ -94,6 +96,11 @@ public class DnsClient implements Dns {
         return this;
     }
 
+    public DnsClient useGlobalCache(boolean enabled) {
+        global_cache = enabled;
+        return this;
+    }
+
     @Override
     public List<InetAddress> lookup(String hostname) throws UnknownHostException {
         if (dns == null) {
@@ -112,6 +119,10 @@ public class DnsClient implements Dns {
         } catch (TextParseException|ExceptionInInitializerError ex) {
             Logger.log(Logger.LEVEL.DEBUG, ex);
             throw new UnknownHostException(hostname);
+        }
+
+        if (!global_cache) {
+            req.setCache(new Cache());
         }
 
         req.setResolver(dns);

--- a/app/src/main/java/pw/thedrhax/mosmetro/httpclient/DnsClient.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/httpclient/DnsClient.java
@@ -126,6 +126,7 @@ public class DnsClient implements Dns {
         }
 
         req.setResolver(dns);
+        wifi.bindToWifi();
 
         Record[] res = req.run();
         List<InetAddress> result = new LinkedList<>();

--- a/app/src/main/java/pw/thedrhax/mosmetro/httpclient/DnsClient.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/httpclient/DnsClient.java
@@ -44,7 +44,7 @@ import pw.thedrhax.util.WifiUtils;
 public class DnsClient implements Dns {
     private final WifiUtils wifi;
     private ExtendedResolver dns;
-    private final boolean pref_dnsjava;
+    private boolean pref_dnsjava;
 
     private String[] getServers() {
         Set<String> servers = new HashSet<String>();
@@ -87,6 +87,11 @@ public class DnsClient implements Dns {
             Logger.log(this, "Unable to initialize, using system resolver");
             dns = null;
         }
+    }
+
+    public DnsClient useCustomClient(boolean enabled) {
+        pref_dnsjava = enabled;
+        return this;
     }
 
     @Override

--- a/app/src/main/java/pw/thedrhax/util/Util.java
+++ b/app/src/main/java/pw/thedrhax/util/Util.java
@@ -27,9 +27,22 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.StringReader;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 public final class Util {
     private Util() {}
+
+    public static InetAddress intToAddr(int hex) throws UnknownHostException {
+        byte[] b = new byte[4];
+
+        b[3] = (byte) ((hex & 0xFF000000) >> 24);
+        b[2] = (byte) ((hex & 0x00FF0000) >> 16);
+        b[1] = (byte) ((hex & 0x0000FF00) >> 8);
+        b[0] = (byte) (hex & 0x000000FF);
+
+        return InetAddress.getByAddress(b);
+    }
 
     // Source: https://stackoverflow.com/a/26779342
     public static int countLines(String input) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -272,4 +272,6 @@
     <string name="auth_midsession_fail">Обработка midsession не сработала. Если это сообщение появляется слишком часто, нажмите &gt;сюда&lt;, чтобы отключить эту функцию.</string>
     <string name="auth_midsession_start">Пытаюсь обойти midsession</string>
     <string name="vpn_warning">Обнаружен VPN! Некоторые VPN или фильтры трафика могут мешать работе приложения, даже если оно находится в списке исключений. Пожалуйста, попробуйте отключить VPN и снова запустить подключение.</string>
+    <string name="pref_wifi_any_ssid">Проверять все сети</string>
+    <string name="pref_wifi_any_ssid_summary">Искать признаки поддерживаемых алгоритмов с помощью быстрой проверки через DNS в сетях Wi-Fi с незнакомым названием.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,4 +299,6 @@
     <string name="auth_midsession_fail">Unable to handle midsession. If you see this message too often, tap &gt;here&lt; to disable this function.</string>
     <string name="auth_midsession_start">Attempting to bypass the midsession</string>
     <string name="vpn_warning">VPN detected! Some VPN apps or traffic filters may interfere with this app even if it was added to blacklist. Please disable the VPN and try again.</string>
+    <string name="pref_wifi_any_ssid">Check every network</string>
+    <string name="pref_wifi_any_ssid_summary">Perform quick DNS check in every unknown Wi-Fi network in attempt to find signs of any supported algorithm.</string>
 </resources>

--- a/app/src/main/res/xml/pref_conn.xml
+++ b/app/src/main/res/xml/pref_conn.xml
@@ -29,6 +29,12 @@
 
     <CheckBoxPreference
         android:defaultValue="false"
+        android:key="pref_wifi_any_ssid"
+        android:title="@string/pref_wifi_any_ssid"
+        android:summary="@string/pref_wifi_any_ssid_summary" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
         android:key="pref_wifi_reconnect"
         android:summary="@string/pref_wifi_reconnect_summary"
         android:title="@string/pref_wifi_reconnect" />


### PR DESCRIPTION
Если система возвращает `<unknown ssid>` вместо настоящего названия сети или в настройках включена опция "Проверять все сети", при подключении к Wi-Fi будет отправлен DNS-запрос.

Ожидается, что в поддерживаемых сетях IP-адрес в одном из ответов DNS будет частным (например, в 10.0.0.0/8). Если это так, то запускается проверка generate_204, и дальше идёт обычное автоматическое подключение.

В результате частично снимается зависимость от доступа к геолокации - приложению достаточно лишь сообщения о самом факте подключения к Wi-Fi.

---

План действий:
* [x] Подтвердить, что метод работает в основных сетях (метро Москвы и СПб, наземный транспорт);
  * Точно работает в сегментах metro, cppk и aeroexpress;
* [x] Убедиться, что ожидание IP ни у кого не сломано из-за нового условия;
* [x] ~Обновить первоначальную настройку (не требовать разрешения не геолокацию в фоне для автоподключения)~;

Тестирование производится в ветке `experimental` (сборка 34 и новее).