### PR TITLE
Новый алгоритм проверки соединения с интернетом

### DIFF
--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/InitialConnectionCheckTask.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/InitialConnectionCheckTask.java
@@ -40,7 +40,7 @@ public abstract class InitialConnectionCheckTask implements Task {
 
         if (!first_start) {
             Logger.log(p.context.getString(R.string.auth_checking_connection));
-            response = p.gen_204.check().getResponse();
+            response = p.gen_204.check(false).getResponse();
         }
 
         first_start = false;

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/Provider.java
@@ -108,9 +108,8 @@ public abstract class Provider extends LinkedList<Task> implements Task {
      */
     @NonNull public static Provider find(Context context, Listener<Boolean> running) {
         Logger.log(context.getString(R.string.auth_provider_check));
-        HttpResponse response = new Gen204(context, running).check().getResponse();
-        Provider result = Provider.find(context, response);
-        return result;
+        HttpResponse response = new Gen204(context, running).check(false).getResponse();
+        return Provider.find(context, response);
     }
 
     /**
@@ -146,7 +145,7 @@ public abstract class Provider extends LinkedList<Task> implements Task {
      * @return True if internet access is available; otherwise, false is returned.
      */
     public boolean isConnected() {
-        return isConnected(gen_204.check().getResponse());
+        return isConnected(gen_204.check(true).getResponse());
     }
 
     /**

--- a/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV2WV.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/authenticator/providers/MosMetroV2WV.java
@@ -293,7 +293,7 @@ public class MosMetroV2WV extends WebViewProvider {
             public boolean until(HashMap<String, Object> vars) {
                 if (pref_internet_check && ++counter == interval * 10) {
                     counter = 0;
-                    Gen204Result res_204 = gen_204.check();
+                    Gen204Result res_204 = gen_204.check(true);
                     return res_204.isConnected() && !res_204.isFalseNegative();
                 }
 

--- a/app/src/main/java/pw/thedrhax/mosmetro/services/ConnectionService.java
+++ b/app/src/main/java/pw/thedrhax/mosmetro/services/ConnectionService.java
@@ -396,7 +396,9 @@ public class ConnectionService extends IntentService {
                 .setGen204(gen_204);
 
         midsession.add(vars -> {
-            if (gen_204.getLastResult().isFalseNegative()) {
+            Gen204Result last_result = gen_204.getLastResult();
+
+            if (last_result != null && last_result.isFalseNegative()) {
                 vars.put("result", Provider.RESULT.ERROR);
             }
 
@@ -413,7 +415,7 @@ public class ConnectionService extends IntentService {
 
         if (!running.sleep(3000)) return false;
 
-        res_204 = gen_204.check();
+        res_204 = gen_204.check(true);
 
         if (!res_204.isConnected()) {
             Logger.log(this, "Midsession | Connection lost, aborting...");
@@ -447,7 +449,7 @@ public class ConnectionService extends IntentService {
     private boolean isConnected(Gen204 gen_204, Gen204Result res_204) {
         if (res_204 == null) {
             Logger.log(this, "Checking internet connection");
-            res_204 = gen_204.check();
+            res_204 = gen_204.check(true);
         }
 
         if (!res_204.isConnected()) {
@@ -468,6 +470,10 @@ public class ConnectionService extends IntentService {
         if (settings.getBoolean("pref_internet_midsession", false)) {
             boolean solved = handleMidsession(gen_204, res_204);
             res_204 = gen_204.getLastResult();
+
+            if (res_204 == null) {
+                res_204 = gen_204.check(true);
+            }
 
             if (solved || !res_204.isConnected()) {
                 return res_204.isConnected();


### PR DESCRIPTION
Отличия от предыдущей реализации:
* В начале подключения отправляется только один запрос по HTTP (а не 2-3);
* Проверка по HTTPS применяется только после попытки авторизации (проверка в начале часто зависала из-за кривого MITM у провайдера);
* Ненадёжные адреса применяются для определения false negative и в случае ошибки соединения по HTTPS, т.е. только для второстепенных целей;

---

План действий:
* [ ] Проверить стабильность работы во всех основных сетях;
* [ ] Добавить в настройки возможность указывать свои адреса generate_204;